### PR TITLE
Ensure wget downloads plantuml jar with consistent filename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update 
 RUN apt-get install -y fonts-ipafont graphviz wget openjdk-8-jre git curl
-RUN wget -P / --content-disposition https://sourceforge.net/projects/plantuml/files/plantuml.jar/download
+RUN wget -P / -O plantuml.jar --content-disposition https://sourceforge.net/projects/plantuml/files/plantuml.jar/download
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
SourceForge was providing a filename with a viasf=1 query param appended which caused the action to begin failing when trying to execute the donwloaded jar.

Example of file download with query param: 
![image](https://github.com/abekoh/commit-plantuml-action/assets/45930010/baae7ff4-925a-4efc-a032-5610fc72c058)
Resulting error when the diagrams are generated:
![image](https://github.com/abekoh/commit-plantuml-action/assets/45930010/69439f0d-5479-4b04-babe-6c1de0de8070)
